### PR TITLE
Add giveaway logging cog for #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ config.py
 .vscode/*
 config.json
 TriggerPhrases.json
+giveaways*.csv
+giveaways-*.json

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A config.json file is required for the bot to run. It looks like this;
             "RESEARCHER": 867125502833852426,
             "NEWSJUNKIE": 865654074274873374,
             "SITDOWN": 866796838098042880,
-            "ADMIN": 904851948598067241
+            "ADMIN": 865684680195964998
         },
 
         "Channels" : {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ A config.json file is required for the bot to run. It looks like this;
             "HELPER": 866128683809767474,
             "RESEARCHER": 867125502833852426,
             "NEWSJUNKIE": 865654074274873374,
-            "SITDOWN": 866796838098042880
+            "SITDOWN": 866796838098042880,
+            "ADMIN": 904851948598067241
         },
 
         "Channels" : {

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,8 @@ bot = commands.Bot(command_prefix=conf["Discord"]["COMMAND_PREFIX"])
 cogs = [
     'cogs.helper_role',
     'cogs.researcher_role',
-    'cogs.censor'
+    'cogs.censor',
+    'cogs.giveaways',
 ]
 
 

--- a/cogs/giveaways.py
+++ b/cogs/giveaways.py
@@ -17,7 +17,7 @@ class Giveaway(commands.Cog):
         
         with open("config.json", 'r') as config_file:
             config = json.load(config_file)
-            self.helper_role = config["Discord"]["Roles"]["HELPER"]
+            self.admin_role = config["Discord"]["Roles"]["ADMIN"]
         
         if not pathlib.Path(self.giveaway_csv).is_file():
             self.make_new_csv()
@@ -26,8 +26,8 @@ class Giveaway(commands.Cog):
     def cog_unload(self):
         self.output_file.close()
         
-    def has_helper_role(self, member):
-        return self.helper_role in [r.id for r in member.roles] or True
+    def has_admin_role(self, member):
+        return self.admin_role in [r.id for r in member.roles]
     
     def has_giveaway_role(self, member):
         return self.giveaway_role in [r.id for r in member.roles]
@@ -47,7 +47,7 @@ class Giveaway(commands.Cog):
             # log user activity to csv if in giveaway channel
             has_role = int(self.has_giveaway_role(msg.author))
             line = f"{int(time.time())},{msg.author.name},{msg.author.id},{has_role}"
-            print("Activity:", line)
+            #print("Activity:", line)
             self.output_file.write(line)
             self.output_file.write("\n")
             self.write_count += 1
@@ -55,10 +55,10 @@ class Giveaway(commands.Cog):
                 self.output_file.flush()  # force write to disk
                 self.write_count = 0
     
-    @commands.command(name="csv-yeet")
+    @commands.command(name="csv-cleargiveaway")
     async def giveup(self, msg):
         """Clear and restart the giveaway CSV file"""
-        if not self.has_helper_role(msg.author):
+        if not self.has_admin_role(msg.author):
             await msg.channel.send("I don't trust you")
             return
         self.output_file.close()

--- a/cogs/giveaways.py
+++ b/cogs/giveaways.py
@@ -1,0 +1,71 @@
+from discord.ext import commands
+import json
+import pathlib
+import time
+
+
+class Giveaway(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.write_count = 0
+        with open("giveaways.json", 'r') as giveaway_config_file:
+            self.config = json.load(giveaway_config_file)
+            self.giveaway_channel = self.config["Discord"]["Channels"]["GIVEAWAY"]
+            self.giveaway_role = self.config["Discord"]["Roles"]["GIVEAWAY"]
+            self.writes_per_flush = self.config["Giveaway"]["writes_per_flush"]
+            self.giveaway_csv = self.config["Giveaway"]["csv"]
+        
+        with open("config.json", 'r') as config_file:
+            config = json.load(config_file)
+            self.helper_role = config["Discord"]["Roles"]["HELPER"]
+        
+        if not pathlib.Path(self.giveaway_csv).is_file():
+            self.make_new_csv()
+        self.output_file = open(self.giveaway_csv, 'a')
+    
+    def cog_unload(self):
+        self.output_file.close()
+        
+    def has_helper_role(self, member):
+        return self.helper_role in [r.id for r in member.roles] or True
+    
+    def has_giveaway_role(self, member):
+        return self.giveaway_role in [r.id for r in member.roles]
+    
+    def make_new_csv(self):
+        """Generate CSV with header"""
+        with open(self.giveaway_csv, 'w') as csv_file:
+            csv_file.write("Unix Timestamp,Username,User ID,Has Role?")
+            csv_file.write("\n")
+    
+    @commands.Cog.listener(name="on_message")
+    async def log_activity(self, msg):
+        """Log messages in the giveaway channel"""
+        if msg.author == self.bot.user:
+            return
+        if msg.channel.id == self.giveaway_channel:
+            # log user activity to csv if in giveaway channel
+            has_role = int(self.has_giveaway_role(msg.author))
+            line = f"{int(time.time())},{msg.author.name},{msg.author.id},{has_role}"
+            print("Activity:", line)
+            self.output_file.write(line)
+            self.output_file.write("\n")
+            self.write_count += 1
+            if self.write_count >= self.writes_per_flush:
+                self.output_file.flush()  # force write to disk
+                self.write_count = 0
+    
+    @commands.command(name="csv-yeet")
+    async def giveup(self, msg):
+        """Clear and restart the giveaway CSV file"""
+        if not self.has_helper_role(msg.author):
+            await msg.channel.send("I don't trust you")
+            return
+        self.output_file.close()
+        self.make_new_csv()
+        self.output_file = open(self.giveaway_csv, 'a')
+        await msg.channel.send(f"Truncated `{self.giveaway_csv}` successfully")
+
+
+def setup(bot):
+    bot.add_cog(Giveaway(bot))

--- a/giveaways.json
+++ b/giveaways.json
@@ -1,0 +1,14 @@
+{
+    "Discord": {
+        "Roles": {
+            "GIVEAWAY": 904851948598067241
+        },
+        "Channels": {
+            "GIVEAWAY": 901524994696286261
+        }
+    },
+    "Giveaway": {
+        "writes_per_flush": 1,
+        "csv": "giveaways_log.csv"
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.7.4
 async-timeout==3.0.1
 attrs==21.2.0
 autopep8==1.5.7
-chardet==4.0.0
+chardet<=4.0.0
 discord==1.7.3
 discord.py==1.7.3
 flake8==3.9.2


### PR DESCRIPTION
This adds giveaway functionality as discussed with Orelio.

A new configuration json called `giveaways.json` to customize the giveaway role and giveaway channel IDs, as well as the output file and file flushing frequency (basically how often the file is saved to disk). The Discord channel and role IDs are currently incorrect because I do not know what to set them to.

This also adds a new command `csv-yeet` which resets the giveaway csv file. Anyone with the helper role can use this command.

This was tested on my own server.