### PR TITLE
Add username sanitisation to fix CSV injections

### DIFF
--- a/cogs/giveaways.py
+++ b/cogs/giveaways.py
@@ -14,6 +14,7 @@ class Giveaway(commands.Cog):
             self.giveaway_role = self.config["Discord"]["Roles"]["GIVEAWAY"]
             self.writes_per_flush = self.config["Giveaway"]["writes_per_flush"]
             self.giveaway_csv = self.config["Giveaway"]["csv"]
+            self.sanitised_chars = self.config["Giveaway"]["sanitised_characters"]
         
         with open("config.json", 'r') as config_file:
             config = json.load(config_file)
@@ -46,7 +47,10 @@ class Giveaway(commands.Cog):
         if msg.channel.id == self.giveaway_channel:
             # log user activity to csv if in giveaway channel
             has_role = int(self.has_giveaway_role(msg.author))
-            line = f"{int(time.time())},{msg.author.name},{msg.author.id},{has_role}"
+            sanitised_name = msg.author.name
+            for chars in self.sanitised_chars:
+                sanitised_name = sanitised_name.replace(chars, "")
+            line = f"{int(time.time())},{sanitised_name},{msg.author.id},{has_role}"
             #print("Activity:", line)
             self.output_file.write(line)
             self.output_file.write("\n")

--- a/giveaways.json
+++ b/giveaways.json
@@ -9,6 +9,7 @@
     },
     "Giveaway": {
         "writes_per_flush": 1,
-        "csv": "giveaways_log.csv"
+        "csv": "giveaways_log.csv",
+        "sanitised_characters": ["\n", ","]
     }
 }


### PR DESCRIPTION
This fixes CSV parsing weirdness caused by a giveaway user with commas in their username. These invalid characters are now removed from the username before it is entered into the giveaway log CSV.

The invalid characters can be customised by adding & removing strings from the list `sanitised_characters` in giveaways.json