### PR TITLE
QnA vote viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ config.json
 TriggerPhrases.json
 giveaways*.csv
 giveaways-*.json
+*.html

--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,7 @@ cogs = [
     'cogs.researcher_role',
     'cogs.censor',
     'cogs.giveaways',
+    'cogs.qna',
 ]
 
 

--- a/cogs/helper_role.py
+++ b/cogs/helper_role.py
@@ -20,7 +20,7 @@ class HelperRole(commands.Cog):
         """
         return self.helper_role in [r.id for r in ctx.author.roles]
 
-    @commands.command()
+    #@commands.command()
     async def sitdown(self, ctx):
         """Add a sitdown role to a set of mentioned users"""
         for user in ctx.message.mentions:
@@ -32,7 +32,7 @@ class HelperRole(commands.Cog):
                 await ctx.send(f"Couldn't put {user} in sit-down. Error:\n{e}")
             await ctx.send(f"Added {user} to sit-down")
 
-    @commands.command()
+    #@commands.command()
     async def sitdownrelease(self, ctx):
         for user in ctx.message.mentions:
             try:

--- a/cogs/qna.py
+++ b/cogs/qna.py
@@ -1,0 +1,92 @@
+from discord.ext import tasks, commands
+import discord
+import json
+
+
+class QnAHelper(commands.Cog):
+    """Manages all stuff associated with the Q&A Channel"""
+
+    def __init__(self, bot):
+        self.bot = bot
+        with open("qna.json", 'r') as config_file:
+            config = json.load(config_file)
+            self.qna_channel = config["Discord"]["Channels"]["QNA"]
+            self.qna_upvote = config["Discord"]["Emojis"]["UPVOTE"]
+            self.html_out = config["Apache"]["site_root"] + "/" + config["Apache"]["filename"]
+            self.truncate = int(config["Apache"]["truncate"])
+        self.questions = dict()
+        #self.debug_questions.start()
+        self.generate_html_output.start()
+
+    def cog_unload(self):
+        self.debug_questions.cancel()
+        self.generate_html_output.cancel()
+
+    async def cog_check(self, ctx):
+        """
+        Precheck that prevents anyone without an apropriate role
+        from using any commands in this cog. This does not need to be called.
+        """
+        return self.helper_role in [r.id for r in ctx.author.roles]
+
+    @commands.Cog.listener(name="on_message")
+    async def new_question(self, msg):
+        self.questions[msg.id] = (msg.id, msg.content, 0)
+
+    @commands.Cog.listener(name="on_message_delete")
+    async def question_removed(self, msg):
+        if msg.id in self.questions:
+            del(self.questions[msg.id])
+
+    @commands.Cog.listener(name="on_message_edit")
+    async def question_modified(self, msg):
+        self.questions[msg.id] = (msg.id, msg.content, 0)
+
+    @commands.Cog.listener(name="on_raw_reaction_add")
+    async def question_vote_added(self, event):
+        if event.emoji.name != self.qna_upvote or event.message_id not in self.questions:
+            return
+        old_val = self.questions[event.message_id]
+        self.questions[event.message_id] = (old_val[0], old_val[1], old_val[2]+1)
+
+    @commands.Cog.listener(name="on_raw_reaction_remove")
+    async def question_vote_removed(self, event):
+        if event.emoji.name != self.qna_upvote or event.message_id not in self.questions:
+            return
+        old_val = self.questions[event.message_id]
+        self.questions[event.message_id] = (old_val[0], old_val[1], old_val[2]-1)
+
+    @tasks.loop(seconds=5.0)
+    async def debug_questions(self):
+        print("----- new tally ----")
+        sorted_questions = self.sort_questions()
+        sorted_strs = list()
+        for q in sorted_questions:
+            sorted_strs.append(f"msg `{q[1]}` has {q[2]} votes")
+        print("\n".join(sorted_strs))
+
+    @tasks.loop(seconds=5.0)
+    async def generate_html_output(self):
+        #print("Writing HTML out")
+        sorted_questions = self.sort_questions()
+        if self.truncate > 0:
+            sorted_questions = sorted_questions[:self.truncate]
+        sorted_strs = list()
+        # generate some HTML the bad/stupid way
+        for q in sorted_questions:
+            sanitised = q[1].replace(">", "").replace("<", "")
+            sorted_strs.append(f"<tr><th>{sanitised}</th><th>{q[2]}</th></tr>")
+        table_innards = "\n".join(sorted_strs)
+        table = "<table><tr><th>Message</th><th>Votes</th></tr>" + table_innards + "</table>"
+        page = "<head><title>Q&A Vote Tally</title><meta charset=\"utf-8\"></head><body><h1 style=\"display: none;\">Questions, ordered by popularity as jankily judged by the SDM Discord Bot</h1>" + table + "</body>"
+        with open(self.html_out, 'w') as html_file:
+            html_file.write(page)
+
+    def sort_questions(self):
+        values = sorted(self.questions.values(), key = lambda item: item[2], reverse = True)
+        return values
+
+
+
+def setup(bot):
+    bot.add_cog(QnAHelper(bot))

--- a/qna.json
+++ b/qna.json
@@ -1,0 +1,16 @@
+{
+    "Discord": {
+        "Channels": {
+            "QNA": 942468602118942750
+        },
+        "Emojis": {
+            "UPVOTE": "👍"
+        }
+    },
+    "Apache": {
+        "site_root": "/var/www/html",
+        "filename": "tally.html",
+        "truncate": 0
+    }
+}
+


### PR DESCRIPTION
This adds an automatically-generated HTML table to display votes in the live-qna channel, which is updated every 5 seconds.
The page isn't very pretty, but it works and that's what counts. This is a quick and simple implementation without any sort of persistence, which means if the bot goes down all previous questions will be lost.

By default, the thumbs up emoji is used for voting and the live-qna channel is monitored. The HTML page is saved to `/var/www/html/tally.html` as well, though it may not have permission to write to that location (and may fail silently).

Note: this also disables the 2 sitdown commands